### PR TITLE
Add release and no-debug flags, plus indentation fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default: src/btest.cr
 	mkdir -p bin
-	crystal build -o bin/btest src/btest.cr
+	crystal build -o bin/btest src/btest.cr --release --no-debug
 
 symlink:
 	ln -sf `pwd`/bin/btest /usr/local/bin/btest

--- a/src/btest.cr
+++ b/src/btest.cr
@@ -302,32 +302,32 @@ class Result
     uncolored_len = @testCase.suite.name.size + 1 + @runner.name.size + 1 + \
       name.size
 
-  # Chop the output if the name is too long
-  chop_delta = uncolored_len - (TERMINAL_WIDTH - 7)
-  if chop_delta > 0
-    name = name[0..name.size - chop_delta]
-    uncolored_len -= chop_delta - 1
-  end
+    # Chop the output if the name is too long
+    chop_delta = uncolored_len - (TERMINAL_WIDTH - 7)
+    if chop_delta > 0
+      name = name[0..name.size - chop_delta]
+      uncolored_len -= chop_delta - 1
+    end
 
-  suite = @testCase.suite.name.colorize(:white)
-  runner = @runner.name.colorize(:dark_gray)
-  ret = "#{runner} #{suite} #{name}"
+    suite = @testCase.suite.name.colorize(:white)
+    runner = @runner.name.colorize(:dark_gray)
+    ret = "#{runner} #{suite} #{name}"
 
-  # Add dots to fill the terminal horizontally
-  dots = ""
-  (TERMINAL_WIDTH - 6 - uncolored_len).times do |_|
-    dots += "."
-  end
-  ret += "#{dots.colorize(:dark_gray)}"
+    # Add dots to fill the terminal horizontally
+    dots = ""
+    (TERMINAL_WIDTH - 6 - uncolored_len).times do |_|
+      dots += "."
+    end
+    ret += "#{dots.colorize(:dark_gray)}"
 
-  # Add the pass/fail indicator
-  pass = @pass ? "PASS".colorize(:green) : "FAIL".colorize(:red)
-  puts(ret + "[#{pass}]")
+    # Add the pass/fail indicator
+    pass = @pass ? "PASS".colorize(:green) : "FAIL".colorize(:red)
+    puts(ret + "[#{pass}]")
 
-  return if @pass
+    return if @pass
 
-  # Show failure information
-  puts(("      " + @message.gsub("\n", "\n      ")).colorize(:dark_gray))
+    # Show failure information
+    puts(("      " + @message.gsub("\n", "\n      ")).colorize(:dark_gray))
   end
 end
 


### PR DESCRIPTION
Hi @briansteffens Another small change, see my comment here: https://github.com/briansteffens/btest/pull/3#issuecomment-377742707

`--release`  enable compiler optimizations
`--no-debug` allow to compile faster bypassing debug info 

Finally, an small formatting issue is fixed as well :+1: 