### PR TITLE
Add -f (test file) command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,17 @@ templates:
 
 ### Run it
 
+Run all tests:
+
 ```bash
 btest
+```
+
+Run just a specific test file by name (assuming the test path root is `tests/`,
+this will run the tests in `tests/important_stuff.yaml`):
+
+```bash
+btest -f important_stuff
 ```
 
 ### More examples


### PR DESCRIPTION
Since there's going to be overlap/interaction between command line
arguments and the config file, I made a new Context class where these
decisions are made/resolved. This then gets passed around in place of a
YAML node.