### PR TITLE
Add circleci build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: dlanguage/ldc
+    steps:
+      - checkout
+      - run:
+          name: Install debian-packaged dependencies
+          command: |
+            apt update
+            apt install -y git build-essential
+            ln -s $(which ldc2) /usr/local/bin/ldc
+      - run:
+          name: Install btest
+          command: |
+            git clone https://github.com/briansteffens/btest
+            cd btest
+            make
+            make install


### PR DESCRIPTION
There aren't tests, but we can at least have a build check step.

I copied this from bsdscheme's circleci config and tested it out against my fork.